### PR TITLE
feat: WebSocket-based mobile remote control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0",
+        "ws": "^8.20.0",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
@@ -35,6 +36,7 @@
         "@types/node": "^22.10.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.2.0",
         "electron": "^41.2.2",
         "electron-builder": "^26.8.1",
@@ -2582,6 +2584,16 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -8830,6 +8842,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
+    "ws": "^8.20.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "electron": "^41.2.2",
     "electron-builder": "^26.8.1",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,6 +5,8 @@ import type {
   AppSettings,
   DownloadJob,
   DownloadRequest,
+  MobileCommand,
+  MobilePlayerState,
   TrackQuery
 } from '../shared/types.js';
 import { getSettings, updateSettings } from './settings.js';
@@ -47,7 +49,13 @@ import {
 import { getSchemaHistory } from './library/db.js';
 import { discoverSonos, addSonosByIp, initSonosFromCache, sonosPlayTrack, sonosPause, sonosResume, sonosStop, sonosSetVolume, sonosSeek, sonosGetPosition } from './sonos.js';
 import { startAudioServer, getTrackHttpUrl } from './sonos-server.js';
-import { startMobileServer, stopMobileServer, generateTrackMobileUrl } from './mobile-server.js';
+import {
+  startMobileServer,
+  stopMobileServer,
+  broadcastPlayerState,
+  getMobileSessionUrl,
+  onMobileCommand
+} from './mobile-server.js';
 import { refreshTrayLanguage } from './tray.js';
 import { checkForUpdates, downloadUpdate, quitAndInstall, getLastUpdaterStatus } from './app-updater.js';
 import { lookupTrackMetadata } from './musicbrainz.js';
@@ -300,8 +308,16 @@ export function registerIpc(): void {
   ipcMain.handle(Channels.SonosPosition, (_evt, host: string) => sonosGetPosition(host));
 
   // ----- Mobile Sync -----
-  ipcMain.handle(Channels.MobileSyncGetUrl, (_evt, trackId: number) => {
-    return generateTrackMobileUrl(trackId);
+  ipcMain.handle(Channels.MobileSessionUrl, () => getMobileSessionUrl());
+
+  // Player state pushed from renderer → broadcast to all WS clients
+  ipcMain.on(Channels.PlayerStateUpdate, (_evt, state: MobilePlayerState) => {
+    broadcastPlayerState(state);
+  });
+
+  // Wire mobile commands (from WS clients) → renderer
+  onMobileCommand((cmd: MobileCommand) => {
+    broadcast(Channels.PlayerCommand, cmd);
   });
 
   // ----- Window Controls -----

--- a/src/main/mobile-server.ts
+++ b/src/main/mobile-server.ts
@@ -3,15 +3,17 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import { getTrack, resolveTrackFilePath } from './library/tracks-repo.js';
+import { WebSocketServer, WebSocket } from 'ws';
+import { getTrack, resolveTrackFilePath, listTracks } from './library/tracks-repo.js';
+import { getMobileUiHtml } from './mobile-ui.js';
+import type { MobilePlayerState, MobileCommand } from '../shared/types.js';
 
 let server: http.Server | null = null;
+let wss: WebSocketServer | null = null;
 let serverPort = 0;
-
-/**
- * Maps trackId -> { token: string, expiresAt: number }
- */
-const tokenRegistry = new Map<number, { token: string; expiresAt: number }>();
+let sessionToken: string | null = null;
+let commandHandler: ((cmd: MobileCommand) => void) | null = null;
+let lastState: MobilePlayerState | null = null;
 
 function getLocalIp(): string {
   const interfaces = os.networkInterfaces();
@@ -26,10 +28,7 @@ function getLocalIp(): string {
   return '127.0.0.1';
 }
 
-function parseRange(
-  rangeHeader: string,
-  total: number
-): { start: number; end: number } | null {
+function parseRange(rangeHeader: string, total: number): { start: number; end: number } | null {
   const [startStr, endStr] = rangeHeader.replace(/bytes=/, '').split('-');
   const start = parseInt(startStr, 10);
   const end = endStr ? parseInt(endStr, 10) : total - 1;
@@ -38,97 +37,176 @@ function parseRange(
   return { start, end: Math.min(end, total - 1) };
 }
 
+function serveFile(
+  res: http.ServerResponse,
+  filePath: string,
+  contentType: string,
+  rangeHeader: string | undefined
+): void {
+  const stat = fs.statSync(filePath);
+  const fileSize = stat.size;
+
+  if (rangeHeader) {
+    const range = parseRange(rangeHeader, fileSize);
+    if (!range) {
+      res.writeHead(416, { 'Content-Range': `bytes */${fileSize}` });
+      res.end();
+      return;
+    }
+    const { start, end } = range;
+    res.writeHead(206, {
+      'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': end - start + 1,
+      'Content-Type': contentType
+    });
+    fs.createReadStream(filePath, { start, end }).pipe(res);
+  } else {
+    res.writeHead(200, {
+      'Content-Length': fileSize,
+      'Accept-Ranges': 'bytes',
+      'Content-Type': contentType
+    });
+    fs.createReadStream(filePath).pipe(res);
+  }
+}
+
+export function onMobileCommand(handler: (cmd: MobileCommand) => void): void {
+  commandHandler = handler;
+}
+
+export function broadcastPlayerState(state: MobilePlayerState): void {
+  lastState = state;
+  if (!wss) return;
+  const msg = JSON.stringify({ type: 'state', data: state });
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
+  }
+}
+
+export function getMobileSessionUrl(): string | null {
+  if (!server || !sessionToken) return null;
+  return `http://${getLocalIp()}:${serverPort}/?token=${sessionToken}`;
+}
+
 export function startMobileServer(port: number): Promise<number> {
   return new Promise((resolve, reject) => {
     if (server) {
       resolve(serverPort);
       return;
     }
+
+    sessionToken = crypto.randomBytes(24).toString('hex');
+
     server = http.createServer((req, res) => {
       const url = new URL(req.url || '/', `http://${req.headers.host}`);
-      const match = url.pathname.match(/^\/download\/(\d+)$/);
-      
-      if (!match) {
-        res.writeHead(404);
-        res.end('Not Found');
-        return;
-      }
-
-      const trackId = parseInt(match[1], 10);
       const token = url.searchParams.get('token');
 
-      // Validate token
-      const registered = tokenRegistry.get(trackId);
-      if (!registered || registered.token !== token || registered.expiresAt < Date.now()) {
+      if (token !== sessionToken) {
         res.writeHead(403);
-        res.end('Forbidden: Invalid or expired token');
+        res.end('Forbidden');
         return;
       }
 
-      const track = getTrack(trackId);
-      const filePath = track ? resolveTrackFilePath(track) : null;
-      if (!filePath || !fs.existsSync(filePath)) {
-        res.writeHead(404);
-        res.end('File Not Found');
+      // Web UI
+      if (url.pathname === '/') {
+        const html = getMobileUiHtml();
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(html);
         return;
       }
 
-      const stat = fs.statSync(filePath);
-      const fileSize = stat.size;
-      const range = req.headers.range;
-      const filename = path.basename(filePath);
-
-      res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(filename)}"`);
-      res.setHeader('Content-Type', 'audio/mpeg');
-
-      if (range) {
-        const parsedRange = parseRange(range, fileSize);
-        if (!parsedRange) {
-          res.writeHead(416, { 'Content-Range': `bytes */${fileSize}` });
-          res.end();
+      // Stream audio: GET /stream/:trackId
+      const streamMatch = url.pathname.match(/^\/stream\/(\d+)$/);
+      if (streamMatch) {
+        const trackId = parseInt(streamMatch[1], 10);
+        const track = getTrack(trackId);
+        const filePath = track ? resolveTrackFilePath(track) : null;
+        if (!filePath || !fs.existsSync(filePath)) {
+          res.writeHead(404);
+          res.end('File Not Found');
           return;
         }
-        const { start, end } = parsedRange;
-        res.writeHead(206, {
-          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
-          'Accept-Ranges': 'bytes',
-          'Content-Length': end - start + 1
-        });
-        fs.createReadStream(filePath, { start, end }).pipe(res);
-      } else {
-        res.writeHead(200, {
-          'Content-Length': fileSize,
-          'Accept-Ranges': 'bytes'
-        });
-        fs.createReadStream(filePath).pipe(res);
+        serveFile(res, filePath, 'audio/mpeg', req.headers.range);
+        return;
       }
+
+      // Thumbnail: GET /thumbnail/:trackId
+      const thumbMatch = url.pathname.match(/^\/thumbnail\/(\d+)$/);
+      if (thumbMatch) {
+        const trackId = parseInt(thumbMatch[1], 10);
+        const track = getTrack(trackId);
+        const thumbPath = track?.thumbnailPath ?? null;
+        if (!thumbPath || !fs.existsSync(thumbPath)) {
+          res.writeHead(404);
+          res.end('Not Found');
+          return;
+        }
+        const ext = path.extname(thumbPath).toLowerCase();
+        const mime =
+          ext === '.png' ? 'image/png' : ext === '.webp' ? 'image/webp' : 'image/jpeg';
+        serveFile(res, thumbPath, mime, undefined);
+        return;
+      }
+
+      // Library JSON: GET /api/tracks
+      if (url.pathname === '/api/tracks') {
+        const tracks = listTracks({});
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(tracks));
+        return;
+      }
+
+      res.writeHead(404);
+      res.end('Not Found');
+    });
+
+    wss = new WebSocketServer({ server });
+
+    wss.on('connection', (ws, req) => {
+      const reqUrl = new URL(req.url || '/', `http://localhost`);
+      const token = reqUrl.searchParams.get('token');
+
+      if (token !== sessionToken) {
+        ws.close(4001, 'Unauthorized');
+        return;
+      }
+
+      // Send current state immediately on connect
+      if (lastState) {
+        ws.send(JSON.stringify({ type: 'state', data: lastState }));
+      }
+
+      ws.on('message', (data) => {
+        try {
+          const cmd = JSON.parse(data.toString()) as MobileCommand;
+          commandHandler?.(cmd);
+        } catch {
+          // ignore malformed messages
+        }
+      });
     });
 
     server.listen(port, '0.0.0.0', () => {
       serverPort = (server!.address() as { port: number }).port;
-      console.log(`[mobile-server] Mobile sync server listening on port ${serverPort}`);
+      console.log(`[mobile-server] Listening on port ${serverPort}`);
       resolve(serverPort);
     });
+
     server.on('error', reject);
   });
 }
 
 export function stopMobileServer(): void {
+  wss?.close();
+  wss = null;
   server?.close();
   server = null;
   serverPort = 0;
-  tokenRegistry.clear();
-}
-
-export function generateTrackMobileUrl(trackId: number): string {
-  if (!server) {
-    throw new Error('Mobile sync server is not running');
-  }
-  const token = crypto.randomBytes(16).toString('hex');
-  // Token expires in 1 hour
-  tokenRegistry.set(trackId, { token, expiresAt: Date.now() + 3600000 });
-  
-  return `http://${getLocalIp()}:${serverPort}/download/${trackId}?token=${token}`;
+  sessionToken = null;
+  lastState = null;
 }
 
 export function isMobileServerRunning(): boolean {

--- a/src/main/mobile-ui.ts
+++ b/src/main/mobile-ui.ts
@@ -1,0 +1,373 @@
+export function getMobileUiHtml(): string {
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>fmusic</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #0f0f0f;
+    --surface: #1a1a1a;
+    --surface2: #242424;
+    --border: #2e2e2e;
+    --accent: #6366f1;
+    --accent2: #818cf8;
+    --text: #f1f1f1;
+    --text2: #999;
+    --text3: #666;
+    --danger: #ef4444;
+    --radius: 12px;
+  }
+  html, body { height: 100%; background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  body { display: flex; flex-direction: column; max-width: 480px; margin: 0 auto; }
+
+  /* Tabs */
+  .tabs { display: flex; background: var(--surface); border-bottom: 1px solid var(--border); flex-shrink: 0; }
+  .tab { flex: 1; padding: 14px 8px; text-align: center; font-size: 13px; font-weight: 500; color: var(--text2); cursor: pointer; transition: color .15s; border: none; background: none; }
+  .tab.active { color: var(--accent2); border-bottom: 2px solid var(--accent); margin-bottom: -1px; }
+
+  /* Content panels */
+  .panel { display: none; flex: 1; overflow-y: auto; overscroll-behavior: contain; }
+  .panel.active { display: flex; flex-direction: column; }
+
+  /* ── Now Playing ── */
+  .now-playing { flex: 1; display: flex; flex-direction: column; align-items: center; padding: 24px 20px 16px; gap: 20px; }
+  .artwork-wrap { width: 100%; aspect-ratio: 1; max-width: 300px; border-radius: var(--radius); overflow: hidden; background: var(--surface2); flex-shrink: 0; box-shadow: 0 8px 32px rgba(0,0,0,.5); }
+  .artwork-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .artwork-placeholder { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; font-size: 64px; opacity: .4; }
+  .track-info { width: 100%; text-align: center; }
+  .track-title { font-size: 18px; font-weight: 700; line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .track-artist { font-size: 14px; color: var(--text2); margin-top: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .track-album { font-size: 12px; color: var(--text3); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+  /* Seek */
+  .seek-wrap { width: 100%; }
+  .seek-bar { width: 100%; -webkit-appearance: none; appearance: none; height: 4px; border-radius: 2px; background: var(--border); outline: none; cursor: pointer; }
+  .seek-bar::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%; background: var(--accent2); cursor: pointer; }
+  .seek-times { display: flex; justify-content: space-between; font-size: 11px; color: var(--text3); margin-top: 6px; }
+
+  /* Controls */
+  .controls { display: flex; align-items: center; justify-content: center; gap: 28px; }
+  .ctrl-btn { background: none; border: none; cursor: pointer; color: var(--text2); font-size: 28px; padding: 8px; border-radius: 50%; transition: color .15s, background .15s; line-height: 1; display: flex; align-items: center; justify-content: center; }
+  .ctrl-btn:active { background: var(--surface2); color: var(--text); }
+  .ctrl-btn.play-btn { color: var(--text); font-size: 36px; background: var(--accent); padding: 14px; width: 64px; height: 64px; }
+  .ctrl-btn.play-btn:active { background: var(--accent2); }
+  .ctrl-btn:disabled { opacity: .3; pointer-events: none; }
+
+  /* Volume */
+  .volume-wrap { display: flex; align-items: center; gap: 10px; width: 100%; }
+  .vol-icon { font-size: 18px; color: var(--text3); }
+  .vol-slider { flex: 1; -webkit-appearance: none; appearance: none; height: 4px; border-radius: 2px; background: var(--border); outline: none; cursor: pointer; }
+  .vol-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; border-radius: 50%; background: var(--text2); cursor: pointer; }
+
+  /* Status bar */
+  .status-bar { height: 32px; display: flex; align-items: center; justify-content: center; gap: 6px; font-size: 12px; color: var(--text3); flex-shrink: 0; background: var(--surface); border-top: 1px solid var(--border); }
+  .status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text3); }
+  .status-dot.connected { background: #22c55e; }
+  .status-dot.error { background: var(--danger); }
+
+  /* ── Queue ── */
+  .section-header { padding: 16px 16px 8px; font-size: 12px; font-weight: 600; color: var(--text3); text-transform: uppercase; letter-spacing: .06em; }
+  .track-row { display: flex; align-items: center; gap: 12px; padding: 10px 16px; cursor: pointer; transition: background .1s; border-bottom: 1px solid var(--border); }
+  .track-row:active { background: var(--surface2); }
+  .track-row.current { background: rgba(99,102,241,.1); }
+  .track-thumb { width: 44px; height: 44px; border-radius: 6px; object-fit: cover; background: var(--surface2); flex-shrink: 0; }
+  .track-thumb-placeholder { width: 44px; height: 44px; border-radius: 6px; background: var(--surface2); flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 18px; color: var(--text3); }
+  .track-meta { flex: 1; min-width: 0; }
+  .track-meta .name { font-size: 14px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .track-meta .sub { font-size: 12px; color: var(--text2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: 2px; }
+  .track-dur { font-size: 12px; color: var(--text3); flex-shrink: 0; }
+  .empty-msg { text-align: center; color: var(--text3); font-size: 14px; padding: 48px 20px; }
+
+  /* Library search */
+  .search-wrap { padding: 12px 16px; position: sticky; top: 0; background: var(--bg); z-index: 1; border-bottom: 1px solid var(--border); }
+  .search-input { width: 100%; background: var(--surface2); border: 1px solid var(--border); color: var(--text); padding: 10px 14px; border-radius: 8px; font-size: 14px; outline: none; }
+  .search-input:focus { border-color: var(--accent); }
+</style>
+</head>
+<body>
+
+<div class="tabs">
+  <button class="tab active" onclick="showTab('now-playing')">Now Playing</button>
+  <button class="tab" onclick="showTab('queue')">Queue</button>
+  <button class="tab" onclick="showTab('library')">Library</button>
+</div>
+
+<!-- Now Playing -->
+<div id="tab-now-playing" class="panel active">
+  <div class="now-playing">
+    <div class="artwork-wrap" id="artwork-wrap">
+      <div class="artwork-placeholder" id="artwork-placeholder">♪</div>
+      <img id="artwork-img" style="display:none" alt="cover">
+    </div>
+    <div class="track-info">
+      <div class="track-title" id="track-title">Nothing playing</div>
+      <div class="track-artist" id="track-artist">—</div>
+      <div class="track-album" id="track-album"></div>
+    </div>
+    <div class="seek-wrap">
+      <input class="seek-bar" id="seek-bar" type="range" min="0" max="100" value="0" step="0.1">
+      <div class="seek-times">
+        <span id="pos-time">0:00</span>
+        <span id="dur-time">0:00</span>
+      </div>
+    </div>
+    <div class="controls">
+      <button class="ctrl-btn" id="btn-prev" onclick="send({type:'prev'})" title="Previous">⏮</button>
+      <button class="ctrl-btn play-btn" id="btn-play" onclick="send({type:'play'})" title="Play/Pause">▶</button>
+      <button class="ctrl-btn" id="btn-next" onclick="send({type:'next'})" title="Next">⏭</button>
+    </div>
+    <div class="volume-wrap">
+      <span class="vol-icon">🔉</span>
+      <input class="vol-slider" id="vol-slider" type="range" min="0" max="1" step="0.01" value="0.9">
+      <span class="vol-icon">🔊</span>
+    </div>
+  </div>
+</div>
+
+<!-- Queue -->
+<div id="tab-queue" class="panel">
+  <div class="section-header">Up Next</div>
+  <div id="queue-list"></div>
+</div>
+
+<!-- Library -->
+<div id="tab-library" class="panel">
+  <div class="search-wrap">
+    <input class="search-input" id="lib-search" placeholder="Search library…" oninput="filterLibrary(this.value)">
+  </div>
+  <div id="library-list"></div>
+</div>
+
+<div class="status-bar">
+  <div class="status-dot" id="status-dot"></div>
+  <span id="status-text">Connecting…</span>
+</div>
+
+<script>
+(function () {
+  const params = new URLSearchParams(location.search);
+  const token = params.get('token') || '';
+  const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = wsProto + '//' + location.host + '/ws?token=' + token;
+
+  let state = null;
+  let ws = null;
+  let seekDragging = false;
+  let allTracks = [];
+
+  // ── WebSocket ──────────────────────────────────────────────
+  function connect() {
+    ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => setStatus('connected', 'Connected');
+
+    ws.onmessage = (e) => {
+      try {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'state') {
+          state = msg.data;
+          render();
+        }
+      } catch {}
+    };
+
+    ws.onclose = () => {
+      setStatus('error', 'Disconnected — retrying…');
+      setTimeout(connect, 3000);
+    };
+
+    ws.onerror = () => {
+      setStatus('error', 'Connection error');
+    };
+  }
+
+  function send(cmd) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(cmd));
+    }
+  }
+
+  window.send = send;
+
+  // ── Status bar ────────────────────────────────────────────
+  function setStatus(type, text) {
+    const dot = document.getElementById('status-dot');
+    dot.className = 'status-dot ' + type;
+    document.getElementById('status-text').textContent = text;
+  }
+
+  // ── Helpers ───────────────────────────────────────────────
+  function fmt(sec) {
+    if (!sec || !isFinite(sec)) return '0:00';
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    return m + ':' + String(s).padStart(2, '0');
+  }
+
+  function thumbUrl(trackId) {
+    return '/thumbnail/' + trackId + '?token=' + token;
+  }
+
+  function thumbOrPlaceholder(track, size) {
+    if (track && track.thumbnailPath) {
+      return '<img class="track-thumb' + (size === 'large' ? '' : '') + '" src="' + thumbUrl(track.id) + '" onerror="this.style.display=\'none\'" alt="">';
+    }
+    return '<div class="track-thumb-placeholder">♪</div>';
+  }
+
+  // ── Render ────────────────────────────────────────────────
+  function render() {
+    if (!state) return;
+
+    const { current, isPlaying, position, duration, volume, queue, queueIndex } = state;
+
+    // Artwork
+    const img = document.getElementById('artwork-img');
+    const ph = document.getElementById('artwork-placeholder');
+    if (current && current.thumbnailPath) {
+      img.src = thumbUrl(current.id);
+      img.style.display = 'block';
+      ph.style.display = 'none';
+    } else {
+      img.style.display = 'none';
+      ph.style.display = 'flex';
+    }
+
+    // Track info
+    document.getElementById('track-title').textContent = current ? current.title : 'Nothing playing';
+    document.getElementById('track-artist').textContent = current ? (current.artist || '—') : '—';
+    document.getElementById('track-album').textContent = current ? (current.album || '') : '';
+
+    // Play/pause button
+    document.getElementById('btn-play').textContent = isPlaying ? '⏸' : '▶';
+    document.getElementById('btn-play').title = isPlaying ? 'Pause' : 'Play';
+    document.getElementById('btn-play').onclick = () => send({ type: isPlaying ? 'pause' : 'play' });
+
+    // Seek bar
+    if (!seekDragging) {
+      const pct = duration > 0 ? (position / duration) * 100 : 0;
+      document.getElementById('seek-bar').value = pct;
+    }
+    document.getElementById('pos-time').textContent = fmt(position);
+    document.getElementById('dur-time').textContent = fmt(duration);
+    document.getElementById('seek-bar').max = 100;
+
+    // Volume
+    const volSlider = document.getElementById('vol-slider');
+    if (document.activeElement !== volSlider) {
+      volSlider.value = volume;
+    }
+
+    // Queue list
+    const ql = document.getElementById('queue-list');
+    if (!queue || queue.length === 0) {
+      ql.innerHTML = '<div class="empty-msg">Queue is empty</div>';
+    } else {
+      ql.innerHTML = queue.map((t, i) => {
+        const active = i === queueIndex ? ' current' : '';
+        return '<div class="track-row' + active + '" onclick="send({type:\'play-track\',trackId:' + t.id + '})">' +
+          thumbOrPlaceholder(t) +
+          '<div class="track-meta">' +
+            '<div class="name">' + esc(t.title) + '</div>' +
+            '<div class="sub">' + esc(t.artist || '—') + '</div>' +
+          '</div>' +
+          '<div class="track-dur">' + fmt(t.durationSec) + '</div>' +
+        '</div>';
+      }).join('');
+    }
+  }
+
+  // ── Seek bar events ───────────────────────────────────────
+  const seekBar = document.getElementById('seek-bar');
+  seekBar.addEventListener('mousedown', () => { seekDragging = true; });
+  seekBar.addEventListener('touchstart', () => { seekDragging = true; }, { passive: true });
+  seekBar.addEventListener('change', () => {
+    seekDragging = false;
+    if (!state || !state.duration) return;
+    const secs = (parseFloat(seekBar.value) / 100) * state.duration;
+    send({ type: 'seek', position: secs });
+  });
+  seekBar.addEventListener('mouseup', () => { seekDragging = false; });
+
+  // ── Volume slider ─────────────────────────────────────────
+  document.getElementById('vol-slider').addEventListener('input', function () {
+    send({ type: 'volume', value: parseFloat(this.value) });
+  });
+
+  // ── Library ───────────────────────────────────────────────
+  function renderLibrary(tracks) {
+    const el = document.getElementById('library-list');
+    if (!tracks || tracks.length === 0) {
+      el.innerHTML = '<div class="empty-msg">Library is empty</div>';
+      return;
+    }
+    el.innerHTML = tracks.map((t) =>
+      '<div class="track-row" onclick="send({type:\'play-track\',trackId:' + t.id + '})">' +
+        thumbOrPlaceholder(t) +
+        '<div class="track-meta">' +
+          '<div class="name">' + esc(t.title) + '</div>' +
+          '<div class="sub">' + esc(t.artist || '—') + '</div>' +
+        '</div>' +
+        '<div class="track-dur">' + fmt(t.durationSec) + '</div>' +
+      '</div>'
+    ).join('');
+  }
+
+  function filterLibrary(q) {
+    const lower = q.toLowerCase();
+    const filtered = lower
+      ? allTracks.filter(t =>
+          t.title.toLowerCase().includes(lower) ||
+          (t.artist && t.artist.toLowerCase().includes(lower)) ||
+          (t.album && t.album.toLowerCase().includes(lower))
+        )
+      : allTracks;
+    renderLibrary(filtered);
+  }
+
+  window.filterLibrary = filterLibrary;
+
+  async function loadLibrary() {
+    try {
+      const res = await fetch('/api/tracks?token=' + token);
+      allTracks = await res.json();
+      renderLibrary(allTracks);
+    } catch {
+      document.getElementById('library-list').innerHTML = '<div class="empty-msg">Failed to load library</div>';
+    }
+  }
+
+  // ── Tabs ──────────────────────────────────────────────────
+  let libraryLoaded = false;
+  window.showTab = function (name) {
+    document.querySelectorAll('.tab').forEach((t, i) => {
+      const names = ['now-playing', 'queue', 'library'];
+      t.classList.toggle('active', names[i] === name);
+    });
+    document.querySelectorAll('.panel').forEach(p => {
+      p.classList.toggle('active', p.id === 'tab-' + name);
+    });
+    if (name === 'library' && !libraryLoaded) {
+      libraryLoaded = true;
+      loadLibrary();
+    }
+  };
+
+  // ── Escape HTML ───────────────────────────────────────────
+  function esc(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  connect();
+})();
+</script>
+</body>
+</html>`;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,8 @@ import type {
   DependencyStatus,
   DownloadJob,
   DownloadRequest,
+  MobileCommand,
+  MobilePlayerState,
   Playlist,
   SearchResult,
   SonosDevice,
@@ -190,8 +192,12 @@ const api = {
   sonosGetPosition: (host: string) =>
     invoke<{ position: number; duration: number }>(Channels.SonosPosition, host),
 
-  // Mobile Sync
-  getMobileSyncUrl: (trackId: number) => invoke<string>(Channels.MobileSyncGetUrl, trackId),
+  // Mobile remote
+  getMobileSessionUrl: () => invoke<string | null>(Channels.MobileSessionUrl),
+  sendPlayerState: (state: MobilePlayerState) =>
+    ipcRenderer.send(Channels.PlayerStateUpdate, state),
+  onMobileCommand: (handler: (cmd: MobileCommand) => void) =>
+    on<MobileCommand>(Channels.PlayerCommand, handler),
 
   // Window Controls
   minimize: () => ipcRenderer.send('window:minimize'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { Sidebar } from './components/Sidebar';
 import { PlayerBar } from './components/PlayerBar';
 import { TrayBridge } from './components/TrayBridge';
+import { MobileBridge } from './components/MobileBridge';
 import { WindowTitleBar } from './components/WindowTitleBar';
 import { DownloadPage } from './pages/DownloadPage';
 import { LibraryPage } from './pages/LibraryPage';
@@ -253,6 +254,7 @@ export function App() {
             <div className="app-shell">
               <WindowTitleBar />
               <TrayBridge />
+              <MobileBridge />
               <Sidebar />
               <main className="main">
                 <Routes>

--- a/src/renderer/src/components/MobileBridge.tsx
+++ b/src/renderer/src/components/MobileBridge.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react';
+import { usePlayerStore } from '../store/player';
+import { useLibraryStore } from '../store/library';
+
+export function MobileBridge() {
+  const current = usePlayerStore((s) => s.current);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const duration = usePlayerStore((s) => s.duration);
+  const volume = usePlayerStore((s) => s.volume);
+  const queue = usePlayerStore((s) => s.queue);
+  const queueIndex = usePlayerStore((s) => s.index);
+
+  const playTrack = usePlayerStore((s) => s.playTrack);
+  const enqueue = usePlayerStore((s) => s.enqueue);
+  const togglePlay = usePlayerStore((s) => s.togglePlay);
+  const pause = usePlayerStore((s) => s.pause);
+  const next = usePlayerStore((s) => s.next);
+  const prev = usePlayerStore((s) => s.prev);
+  const seek = usePlayerStore((s) => s.seek);
+  const setVolume = usePlayerStore((s) => s.setVolume);
+  const tracks = useLibraryStore((s) => s.tracks);
+
+  // Broadcast meaningful state changes (track, play/pause, queue, volume) immediately.
+  useEffect(() => {
+    window.fmusic.sendPlayerState({
+      current,
+      isPlaying,
+      position: usePlayerStore.getState().position,
+      duration,
+      volume,
+      queue,
+      queueIndex
+    });
+  }, [current, isPlaying, duration, volume, queue, queueIndex]);
+
+  // Broadcast position updates every second so the seek bar stays in sync.
+  const posTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    posTimerRef.current = setInterval(() => {
+      const s = usePlayerStore.getState();
+      window.fmusic.sendPlayerState({
+        current: s.current,
+        isPlaying: s.isPlaying,
+        position: s.position,
+        duration: s.duration,
+        volume: s.volume,
+        queue: s.queue,
+        queueIndex: s.index
+      });
+    }, 1000);
+    return () => {
+      if (posTimerRef.current !== null) clearInterval(posTimerRef.current);
+    };
+  }, []);
+
+  // Handle commands coming from mobile clients via WebSocket → main → renderer.
+  useEffect(() => {
+    return window.fmusic.onMobileCommand((cmd) => {
+      switch (cmd.type) {
+        case 'play':
+          togglePlay();
+          break;
+        case 'pause':
+          pause();
+          break;
+        case 'next':
+          void next();
+          break;
+        case 'prev':
+          void prev();
+          break;
+        case 'seek':
+          seek(cmd.position);
+          break;
+        case 'volume':
+          setVolume(cmd.value);
+          break;
+        case 'play-track': {
+          const track = tracks.find((t) => t.id === cmd.trackId);
+          if (track) void playTrack(track, tracks);
+          break;
+        }
+        case 'enqueue': {
+          const track = tracks.find((t) => t.id === cmd.trackId);
+          if (track) enqueue(track);
+          break;
+        }
+      }
+    });
+  }, [togglePlay, pause, next, prev, seek, setVolume, playTrack, enqueue, tracks]);
+
+  return null;
+}

--- a/src/renderer/src/pages/LibraryPage.tsx
+++ b/src/renderer/src/pages/LibraryPage.tsx
@@ -109,7 +109,7 @@ export function LibraryPage() {
     setMobileSyncTrackId(trackId);
     setMobileSyncUrl(null);
     try {
-      const url = await window.fmusic.getMobileSyncUrl(trackId);
+      const url = await window.fmusic.getMobileSessionUrl();
       setMobileSyncUrl(url);
     } catch (err) {
       alert(t('common.error') + ': ' + (err instanceof Error ? err.message : String(err)));

--- a/src/renderer/src/pages/PlaylistsPage.tsx
+++ b/src/renderer/src/pages/PlaylistsPage.tsx
@@ -180,7 +180,7 @@ function PlaylistDetail({ playlist }: { playlist: Playlist }) {
     setMobileSyncTrackId(trackId);
     setMobileSyncUrl(null);
     try {
-      const url = await window.fmusic.getMobileSyncUrl(trackId);
+      const url = await window.fmusic.getMobileSessionUrl();
       setMobileSyncUrl(url);
     } catch (err) {
       alert(t('common.error') + ': ' + (err instanceof Error ? err.message : String(err)));

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -81,6 +81,11 @@ export const Channels = {
 
   // Mobile Sync
   MobileSyncGetUrl: 'mobile-sync:get-url',
+  MobileSessionUrl: 'mobile:session-url',
+
+  // Mobile player bridge
+  PlayerStateUpdate: 'player:state-update', // renderer → main (ipcRenderer.send)
+  PlayerCommand: 'player:command',           // main → renderer (webContents.send)
 
   // Window Controls
   WindowMaximizeChange: 'window:maximize-change', // event, main -> renderer

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -149,6 +149,26 @@ export interface DependencyStatus {
   ffprobe: { present: boolean; path: string | null };
 }
 
+export interface MobilePlayerState {
+  current: Track | null;
+  isPlaying: boolean;
+  position: number;
+  duration: number;
+  volume: number;
+  queue: Track[];
+  queueIndex: number;
+}
+
+export type MobileCommand =
+  | { type: 'play' }
+  | { type: 'pause' }
+  | { type: 'next' }
+  | { type: 'prev' }
+  | { type: 'seek'; position: number }
+  | { type: 'volume'; value: number }
+  | { type: 'play-track'; trackId: number }
+  | { type: 'enqueue'; trackId: number };
+
 export type TrackSortKey = 'title' | 'artist' | 'album' | 'genre' | 'durationSec' | 'downloadedAt';
 export type SortDirection = 'asc' | 'desc';
 


### PR DESCRIPTION
Replaces the per-track token download mechanism with a full real-time
remote control interface accessible via a single session QR code.

- mobile-server: adds WebSocket server (ws) on the same HTTP port so all
  connected clients receive live player state broadcasts; exposes
  /stream/:id (audio), /thumbnail/:id (cover art) and /api/tracks (JSON
  library) under a single session token
- mobile-ui: self-contained HTML/CSS/JS web app served by the HTTP server
  with Now Playing, Queue and Library tabs; connects via WebSocket and
  sends play/pause/next/prev/seek/volume/play-track commands
- MobileBridge: renderer component (mirroring TrayBridge) that pushes
  full player state to main on meaningful changes and every second for
  seek-bar sync, and handles incoming mobile commands on the Zustand store
- ipc: wires PlayerStateUpdate (renderer→main→WS broadcast) and
  PlayerCommand (WS→main→renderer) channels; adds MobileSessionUrl
- shared: adds MobilePlayerState and MobileCommand types; adds three
  new IPC channels

https://claude.ai/code/session_016AnviMYeCVBcKs8o7eULxG