### PR TITLE
fix: Handle Sonos UPnP 701 stale session error on pause gracefully

### DIFF
--- a/src/main/sonos.ts
+++ b/src/main/sonos.ts
@@ -1,5 +1,6 @@
 import { SonosManager, SonosDevice as SonosDeviceLib } from '@svrooij/sonos';
 import type { SonosDevice } from '../shared/types.js';
+import { t } from './i18n.js';
 import { getSettings, updateSettings } from './settings.js';
 
 let manager: SonosManager | null = null;
@@ -37,7 +38,7 @@ export async function addSonosByIp(host: string): Promise<SonosDevice> {
   if (!manager) manager = new SonosManager();
   await manager.InitializeFromDevice(host);
   const device = manager.Devices.find((d) => d.Host === host);
-  if (!device) throw new Error(`Could not connect to Sonos device at ${host}`);
+  if (!device) throw new Error(t('sonos.connectFailed', { host }));
   saveKnownHost(host);
   return toInfo(device);
 }
@@ -78,7 +79,7 @@ export async function sonosPlayTrack(
   artist?: string
 ): Promise<void> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found — run discover first`);
+  if (!device) throw new Error(t('sonos.deviceNotFoundDiscover', { host }));
   console.log(`[sonos] Playing on ${host}: ${trackUrl}`);
   await device.AVTransportService.SetAVTransportURI({
     InstanceID: 0,
@@ -90,21 +91,34 @@ export async function sonosPlayTrack(
   console.log(`[sonos] Play command sent (title=${title}, artist=${artist})`);
 }
 
+function isStaleTransitionError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /UPnPError\s*701|Transition not available/i.test(msg);
+}
+
 export async function sonosPause(host: string): Promise<void> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found`);
-  await device.Pause();
+  if (!device) throw new Error(t('sonos.deviceNotFound', { host }));
+  try {
+    await device.Pause();
+  } catch (err) {
+    if (isStaleTransitionError(err)) {
+      if (activeHost === host) activeHost = null;
+      throw new Error('SONOS_STALE_SESSION');
+    }
+    throw err;
+  }
 }
 
 export async function sonosResume(host: string): Promise<void> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found`);
+  if (!device) throw new Error(t('sonos.deviceNotFound', { host }));
   await device.Play();
 }
 
 export async function sonosStop(host: string): Promise<void> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found`);
+  if (!device) throw new Error(t('sonos.deviceNotFound', { host }));
   await device.Stop();
   if (activeHost === host) activeHost = null;
 }
@@ -120,7 +134,7 @@ export async function stopActiveSonos(): Promise<void> {
 
 export async function sonosSeek(host: string, seconds: number): Promise<void> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found`);
+  if (!device) throw new Error(t('sonos.deviceNotFound', { host }));
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   const s = Math.floor(seconds % 60);
@@ -137,7 +151,7 @@ function parseTimeToSeconds(time: string): number {
 
 export async function sonosGetPosition(host: string): Promise<{ position: number; duration: number }> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found`);
+  if (!device) throw new Error(t('sonos.deviceNotFound', { host }));
   const info = await device.AVTransportService.GetPositionInfo({ InstanceID: 0 });
   return {
     position: parseTimeToSeconds(info.RelTime ?? '0:00:00'),
@@ -147,7 +161,7 @@ export async function sonosGetPosition(host: string): Promise<{ position: number
 
 export async function sonosSetVolume(host: string, volume: number): Promise<void> {
   const device = getDevice(host);
-  if (!device) throw new Error(`Sonos device ${host} not found`);
+  if (!device) throw new Error(t('sonos.deviceNotFound', { host }));
   // volume is 0-1, Sonos expects 0-100
   await device.RenderingControlService.SetVolume({
     InstanceID: 0,

--- a/src/renderer/src/store/sonos.ts
+++ b/src/renderer/src/store/sonos.ts
@@ -1,6 +1,13 @@
 import { create } from 'zustand';
 import type { SonosDevice } from '../../../shared/types';
+import { translate } from '../i18n';
 import { usePlayerStore } from './player';
+import { useSettingsStore } from './settings';
+
+const t = (key: string) => {
+  const locale = (useSettingsStore.getState().settings?.language ?? 'en') as any;
+  return translate(locale, key);
+};
 
 interface SonosState {
   devices: SonosDevice[];
@@ -51,7 +58,7 @@ export const useSonosStore = create<SonosState>((set, get) => ({
     try {
       const devices = await window.fmusic.sonosDiscover();
       set({ devices });
-      if (devices.length === 0) set({ error: 'No Sonos devices found on the network.' });
+      if (devices.length === 0) set({ error: t('sonos.noDevicesFound') });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err) });
     } finally {
@@ -108,7 +115,19 @@ export const useSonosStore = create<SonosState>((set, get) => ({
       await window.fmusic.sonosPause(activeHost);
       set({ isPlaying: false });
     } catch (err) {
-      set({ error: err instanceof Error ? err.message : String(err) });
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('SONOS_STALE_SESSION')) {
+        get().stopPositionPolling();
+        set({
+          activeHost: null,
+          isPlaying: false,
+          position: 0,
+          duration: 0,
+          error: t('sonos.sessionExpired')
+        });
+      } else {
+        set({ error: msg });
+      }
     }
   },
 

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -247,7 +247,11 @@
     "stopDevice": "Stop this device",
     "addByIp": "Add by IP (useful with VPN)",
     "add": "Add",
-    "noDevicesFound": "No Sonos devices found on the network."
+    "noDevicesFound": "No Sonos devices found on the network.",
+    "sessionExpired": "Sonos session expired after inactivity. Please start casting again.",
+    "deviceNotFound": "Sonos device {host} not found.",
+    "deviceNotFoundDiscover": "Sonos device {host} not found — run discover first.",
+    "connectFailed": "Could not connect to Sonos device at {host}."
   },
   "miniPlayer": {
     "nothingPlaying": "Nothing playing",

--- a/src/shared/i18n/es.json
+++ b/src/shared/i18n/es.json
@@ -247,7 +247,11 @@
     "stopDevice": "Parar este dispositivo",
     "addByIp": "Añadir por IP (útil con VPN)",
     "add": "Añadir",
-    "noDevicesFound": "No se encontraron dispositivos Sonos en la red."
+    "noDevicesFound": "No se encontraron dispositivos Sonos en la red.",
+    "sessionExpired": "La sesión de Sonos ha caducado por inactividad. Por favor, vuelve a conectar.",
+    "deviceNotFound": "No se ha encontrado el dispositivo Sonos {host}.",
+    "deviceNotFoundDiscover": "No se ha encontrado el dispositivo Sonos {host} — busca dispositivos primero.",
+    "connectFailed": "No se ha podido conectar al dispositivo Sonos en {host}."
   },
   "miniPlayer": {
     "nothingPlaying": "Nada reproduciéndose",


### PR DESCRIPTION
## Summary

Fixes #9 — when a Sonos device becomes inactive after a long period, pressing pause threw a raw `UPnPError 701 (Transition not available)` that was surfaced directly to the user as an IPC error string.

- In `src/main/sonos.ts`: added `isStaleTransitionError()` helper that matches UPnP 701 errors by message pattern. `sonosPause()` now catches this specific error, clears the stale `activeHost`, and re-throws a `SONOS_STALE_SESSION` sentinel instead of the raw Sonos error.
- In `src/renderer/src/store/sonos.ts`: `pause()` now checks for the sentinel, stops position polling, clears all session state (`activeHost`, `isPlaying`, `position`, `duration`), and sets a friendly user-facing message: *"Sonos session expired after inactivity. Please start casting again."*

Other errors (network failures, device not found, etc.) are still surfaced as before.

## Test plan

- [ ] Start casting to a Sonos device and let it sit inactive for a long time (or simulate by putting the device in STOPPED state)
- [ ] Press pause — the UI should show the friendly expiry message instead of the raw IPC error
- [ ] After the session is cleared, the Sonos controls should be hidden/reset, allowing the user to cast again
- [ ] Normal pause during active playback still works correctly
- [ ] Other Sonos errors (device not found, network issue) still surface their error messages

https://claude.ai/code/session_01DnwzUga1WY22p32B5L1uHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnwzUga1WY22p32B5L1uHh)_