### PR TITLE
fix: show mini player only on close-to-tray, not on focus loss

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -200,22 +200,21 @@ function createWindow(): void {
     mainWindow?.webContents.send(Channels.WindowMaximizeChange, false);
   });
 
-  // Tie the mini player's visibility to the main window: it only appears
-  // when the main window is hidden (closed to tray), never alongside it.
-  mainWindow.on('hide', () => {
-    if (getSettings().miniPlayerEnabled) showMiniPlayer();
-  });
+  // Hide the mini player whenever the main window becomes visible again.
   mainWindow.on('show', () => {
     hideMiniPlayer();
   });
 
   // Intercept close: hide to tray or quit depending on user setting.
+  // The mini player is shown here — and only here — so that focus loss
+  // never accidentally triggers it.
   mainWindow.on('close', (e) => {
     if (!isQuitting) {
-      const { closeToTray } = getSettings();
+      const { closeToTray, miniPlayerEnabled } = getSettings();
       if (closeToTray) {
         e.preventDefault();
         mainWindow?.hide();
+        if (miniPlayerEnabled) showMiniPlayer();
       } else {
         isQuitting = true;
         app.quit();


### PR DESCRIPTION
## Summary

Fixes #10

- The `hide` event on the main `BrowserWindow` fires on macOS whenever the window loses focus (e.g. switching to another app), not only when `window.hide()` is called intentionally.
- This caused `showMiniPlayer()` to be triggered on every focus loss instead of only when the user closes the main window to the tray.
- Fix: remove the `mainWindow.on('hide', ...)` listener and move the `showMiniPlayer()` call directly into the `close` handler's close-to-tray branch, so the mini player is shown only after an explicit close-to-tray action.

## Test plan

- [ ] Enable mini player in Settings and enable close-to-tray.
- [ ] Switch focus to another app — mini player should **not** appear.
- [ ] Close the main window (close-to-tray) — mini player **should** appear.
- [ ] Click expand in the mini player — main window should restore and mini player should hide.
- [ ] Disable mini player, close to tray — mini player should **not** appear (main window stays hidden).
