### PR TITLE
feat: Persist YouTube source URL for tracks and playlists

### DIFF
--- a/src/main/download-manager.ts
+++ b/src/main/download-manager.ts
@@ -11,7 +11,7 @@ import type {
 } from '../shared/types.js';
 import { DownloadProcess } from './ytdlp.js';
 import { getSettings } from './settings.js';
-import { findByYoutubeId, insertTrack } from './library/tracks-repo.js';
+import { findByYoutubeId, insertTrack, updateTrackSourceUrl } from './library/tracks-repo.js';
 import { addTrackToPlaylist } from './library/playlists-repo.js';
 
 type Listener = (...args: unknown[]) => void;
@@ -222,6 +222,10 @@ export class DownloadManager extends EventEmitter {
       const existing = findByYoutubeId(result.youtubeId);
       if (existing) {
         track = existing;
+        if (!track.sourceUrl) {
+          updateTrackSourceUrl(track.id, job.request.url);
+          track.sourceUrl = job.request.url;
+        }
       } else {
         track = insertTrack({
           youtubeId: result.youtubeId,
@@ -231,7 +235,8 @@ export class DownloadManager extends EventEmitter {
           genre,
           durationSec,
           filePath: result.filePath,
-          thumbnailPath: null
+          thumbnailPath: null,
+          sourceUrl: job.request.url
         });
       }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -28,6 +28,7 @@ import {
   listTracks,
   resolveTrackFilePath,
   updateTrack,
+  updateTrackSourceUrl,
   getTrack,
   getTrackEmbeddedArtworkDataUrl,
   editTrack,
@@ -233,7 +234,10 @@ export function registerIpc(): void {
 
   // ----- Playlists -----
   ipcMain.handle(Channels.PlaylistsList, () => listPlaylists());
-  ipcMain.handle(Channels.PlaylistsCreate, (_evt, name: string) => createPlaylist(name));
+  ipcMain.handle(
+    Channels.PlaylistsCreate,
+    (_evt, name: string, sourceUrl: string | null = null) => createPlaylist(name, sourceUrl)
+  );
   ipcMain.handle(Channels.PlaylistsRename, (_evt, id: number, name: string) =>
     renamePlaylist(id, name)
   );
@@ -260,16 +264,19 @@ export function registerIpc(): void {
   });
   ipcMain.handle(
     Channels.PlaylistsAddTracksByYoutubeIds,
-    (_evt, playlistId: number, youtubeIds: string[]) => {
+    (_evt, playlistId: number, youtubeIdToUrl: Record<string, string>) => {
       // Adds every library track whose YouTube id is in the list to the given
       // playlist. Used when importing a YouTube playlist that contains videos
       // we already have locally — we still want them to appear in the newly
       // created local playlist, just without downloading them again.
       let added = 0;
-      for (const ytId of youtubeIds) {
+      for (const [ytId, url] of Object.entries(youtubeIdToUrl)) {
         const track = findByYoutubeId(ytId);
         if (!track) continue;
         try {
+          if (!track.sourceUrl && url) {
+            updateTrackSourceUrl(track.id, url);
+          }
           addTrackToPlaylist(playlistId, track.id);
           added++;
         } catch {

--- a/src/main/library/migrations/005_source_urls.sql
+++ b/src/main/library/migrations/005_source_urls.sql
@@ -1,0 +1,10 @@
+-- 005_source_urls: remember where a track or a playlist originally came from.
+--
+-- `source_url` is set to the canonical YouTube URL for tracks downloaded
+-- from YouTube and to the canonical playlist URL for local playlists created
+-- from a YouTube playlist import. It is NULL for tracks/playlists that have
+-- no external origin (manual imports, user-created playlists, tracks derived
+-- by the in-app audio editor).
+
+ALTER TABLE tracks ADD COLUMN source_url TEXT;
+ALTER TABLE playlists ADD COLUMN source_url TEXT;

--- a/src/main/library/migrations/index.ts
+++ b/src/main/library/migrations/index.ts
@@ -9,6 +9,7 @@ import m001 from './001_initial.sql?raw';
 import m002 from './002_favorites.sql?raw';
 import m003 from './003_rename_favorites.sql?raw';
 import m004 from './004_playlist_slug.sql?raw';
+import m005 from './005_source_urls.sql?raw';
 
 export interface MigrationDefinition {
   version: number;
@@ -20,5 +21,6 @@ export const migrations: MigrationDefinition[] = [
   { version: 1, name: '001_initial', sql: m001 },
   { version: 2, name: '002_favorites', sql: m002 },
   { version: 3, name: '003_rename_favorites', sql: m003 },
-  { version: 4, name: '004_playlist_slug', sql: m004 }
+  { version: 4, name: '004_playlist_slug', sql: m004 },
+  { version: 5, name: '005_source_urls', sql: m005 }
 ];

--- a/src/main/library/playlists-repo.ts
+++ b/src/main/library/playlists-repo.ts
@@ -8,6 +8,7 @@ interface PlaylistRow {
   created_at: string;
   cover_path: string | null;
   track_count: number;
+  source_url: string | null;
 }
 
 function rowToPlaylist(row: PlaylistRow): Playlist {
@@ -17,12 +18,13 @@ function rowToPlaylist(row: PlaylistRow): Playlist {
     slug: row.slug,
     createdAt: row.created_at,
     coverPath: row.cover_path,
-    trackCount: row.track_count
+    trackCount: row.track_count,
+    sourceUrl: row.source_url
   };
 }
 
 const SELECT_WITH_COUNT = `
-  SELECT p.id, p.name, p.slug, p.created_at, p.cover_path,
+  SELECT p.id, p.name, p.slug, p.created_at, p.cover_path, p.source_url,
          COUNT(pt.track_id) AS track_count
   FROM playlists p
   LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
@@ -54,8 +56,10 @@ export function getPlaylist(id: number): Playlist | null {
   return row ? rowToPlaylist(row) : null;
 }
 
-export function createPlaylist(name: string): Playlist {
-  const res = getDb().prepare('INSERT INTO playlists(name) VALUES (?)').run(name);
+export function createPlaylist(name: string, sourceUrl: string | null = null): Playlist {
+  const res = getDb()
+    .prepare('INSERT INTO playlists(name, source_url) VALUES (?, ?)')
+    .run(name, sourceUrl);
   return getPlaylist(Number(res.lastInsertRowid))!;
 }
 

--- a/src/main/library/tracks-repo.ts
+++ b/src/main/library/tracks-repo.ts
@@ -27,6 +27,7 @@ interface TrackRow {
   downloaded_at: string;
   play_count: number;
   last_played_at: string | null;
+  source_url: string | null;
 }
 
 function rowToTrack(row: TrackRow): Track {
@@ -42,7 +43,8 @@ function rowToTrack(row: TrackRow): Track {
     thumbnailPath: row.thumbnail_path,
     downloadedAt: row.downloaded_at,
     playCount: row.play_count,
-    lastPlayedAt: row.last_played_at
+    lastPlayedAt: row.last_played_at,
+    sourceUrl: row.source_url
   };
 }
 
@@ -55,6 +57,7 @@ export interface NewTrack {
   durationSec: number | null;
   filePath: string;
   thumbnailPath: string | null;
+  sourceUrl: string | null;
 }
 
 export function insertTrack(track: NewTrack): Track {
@@ -62,8 +65,8 @@ export function insertTrack(track: NewTrack): Track {
   const result = db
     .prepare(
       `INSERT INTO tracks
-       (youtube_id, title, artist, album, genre, duration_sec, file_path, thumbnail_path)
-       VALUES (@youtubeId, @title, @artist, @album, @genre, @durationSec, @filePath, @thumbnailPath)`
+       (youtube_id, title, artist, album, genre, duration_sec, file_path, thumbnail_path, source_url)
+       VALUES (@youtubeId, @title, @artist, @album, @genre, @durationSec, @filePath, @thumbnailPath, @sourceUrl)`
     )
     .run(track);
   return getTrack(Number(result.lastInsertRowid))!;
@@ -212,6 +215,10 @@ export function updateTrack(
   return getTrack(id);
 }
 
+export function updateTrackSourceUrl(id: number, sourceUrl: string): void {
+  getDb().prepare('UPDATE tracks SET source_url = ? WHERE id = ?').run(sourceUrl, id);
+}
+
 export function deleteTrack(id: number): boolean {
   const res = getDb().prepare('DELETE FROM tracks WHERE id = ?').run(id);
   return res.changes > 0;
@@ -355,7 +362,8 @@ export async function editTrack(
       genre: track.genre,
       durationSec,
       filePath: newDestPath,
-      thumbnailPath: track.thumbnailPath
+      thumbnailPath: track.thumbnailPath,
+      sourceUrl: null
     });
 
     return newTrack;

--- a/src/main/screenshot-mode.ts
+++ b/src/main/screenshot-mode.ts
@@ -142,7 +142,8 @@ export function seedScreenshotDemoData(userDataDir: string): DemoSeedResult {
       genre: demo.genre,
       durationSec: demo.durationSec,
       filePath,
-      thumbnailPath: null
+      thumbnailPath: null,
+      sourceUrl: null
     });
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -113,7 +113,8 @@ const api = {
 
   // Playlists
   listPlaylists: () => invoke<Playlist[]>(Channels.PlaylistsList),
-  createPlaylist: (name: string) => invoke<Playlist>(Channels.PlaylistsCreate, name),
+  createPlaylist: (name: string, sourceUrl: string | null = null) =>
+    invoke<Playlist>(Channels.PlaylistsCreate, name, sourceUrl),
   renamePlaylist: (id: number, name: string) =>
     invoke<Playlist | null>(Channels.PlaylistsRename, id, name),
   deletePlaylist: (id: number) => invoke<boolean>(Channels.PlaylistsDelete, id),
@@ -132,8 +133,8 @@ const api = {
     );
     return new Map(tuples);
   },
-  addTracksByYoutubeIdsToPlaylist: (playlistId: number, youtubeIds: string[]) =>
-    invoke<number>(Channels.PlaylistsAddTracksByYoutubeIds, playlistId, youtubeIds),
+  addTracksByYoutubeIdsToPlaylist: (playlistId: number, youtubeIdToUrl: Record<string, string>) =>
+    invoke<number>(Channels.PlaylistsAddTracksByYoutubeIds, playlistId, youtubeIdToUrl),
 
   // Schema
   schemaHistory: () =>

--- a/src/renderer/src/__tests__/PlayerBar.test.tsx
+++ b/src/renderer/src/__tests__/PlayerBar.test.tsx
@@ -29,6 +29,7 @@ const mockTrack: Track = {
   downloadedAt: '2024-01-01',
   playCount: 5,
   lastPlayedAt: '2024-01-10',
+  sourceUrl: null,
 };
 
 const favoritesPlaylist: Playlist = {
@@ -38,6 +39,7 @@ const favoritesPlaylist: Playlist = {
   createdAt: '2024-01-01',
   coverPath: null,
   trackCount: 3,
+  sourceUrl: null,
 };
 
 const mockTogglePlay = vi.fn();

--- a/src/renderer/src/__tests__/Sidebar.test.tsx
+++ b/src/renderer/src/__tests__/Sidebar.test.tsx
@@ -14,8 +14,8 @@ vi.mock('../store/settings', () => ({
 }));
 
 const mockPlaylists: Playlist[] = [
-  { id: 1, name: 'Favorites', slug: 'favorites', createdAt: '2024-01-01', coverPath: null, trackCount: 5 },
-  { id: 2, name: 'Road Trip', slug: null, createdAt: '2024-01-02', coverPath: null, trackCount: 12 },
+  { id: 1, name: 'Favorites', slug: 'favorites', createdAt: '2024-01-01', coverPath: null, trackCount: 5, sourceUrl: null },
+  { id: 2, name: 'Road Trip', slug: null, createdAt: '2024-01-02', coverPath: null, trackCount: 12, sourceUrl: null },
 ];
 
 function renderSidebar() {

--- a/src/renderer/src/__tests__/SonosPanel.test.tsx
+++ b/src/renderer/src/__tests__/SonosPanel.test.tsx
@@ -28,6 +28,7 @@ const mockTrack: Track = {
   downloadedAt: '2024-01-01',
   playCount: 0,
   lastPlayedAt: null,
+  sourceUrl: null,
 };
 
 const mockDevices: SonosDevice[] = [

--- a/src/renderer/src/__tests__/TrayBridge.test.tsx
+++ b/src/renderer/src/__tests__/TrayBridge.test.tsx
@@ -25,6 +25,7 @@ const mockTrack: Track = {
   downloadedAt: '2024-01-01',
   playCount: 0,
   lastPlayedAt: null,
+  sourceUrl: null,
 };
 
 const mockNext = vi.fn().mockResolvedValue(undefined);

--- a/src/renderer/src/pages/DownloadPage.tsx
+++ b/src/renderer/src/pages/DownloadPage.tsx
@@ -147,7 +147,7 @@ export function DownloadPage() {
       // step automatically once the track lands in the library.
       let localPlaylist: { id: number };
       try {
-        localPlaylist = await window.fmusic.createPlaylist(playlistTitle);
+        localPlaylist = await window.fmusic.createPlaylist(playlistTitle, url);
         await refreshPlaylists();
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
@@ -160,12 +160,13 @@ export function DownloadPage() {
 
       // Anything already in the library should still end up in the newly
       // created local playlist — we just skip the download part.
-      const preExistingIds = entryIds.filter((id) => alreadyIn.has(id));
-      if (preExistingIds.length > 0) {
+      const preExisting = entries.filter((e) => alreadyIn.has(e.id));
+      if (preExisting.length > 0) {
         try {
+          const idToUrl = Object.fromEntries(preExisting.map((e) => [e.id, e.url]));
           await window.fmusic.addTracksByYoutubeIdsToPlaylist(
             localPlaylist.id,
-            preExistingIds
+            idToUrl
           );
           await refreshPlaylists();
         } catch {

--- a/src/renderer/src/pages/EditPage.tsx
+++ b/src/renderer/src/pages/EditPage.tsx
@@ -357,6 +357,23 @@ export function EditPage() {
           </div>
         )}
 
+        <div className="editor-file-location">
+          <span className="editor-file-location-label">{t('editor.sourceUrl')}</span>
+          {track.sourceUrl ? (
+            <>
+              <code>{track.sourceUrl}</code>
+              <button
+                onClick={() => void window.fmusic.openExternal(track.sourceUrl!)}
+                title={t('editor.openSource')}
+              >
+                {t('editor.openSource')}
+              </button>
+            </>
+          ) : (
+            <small>{t('editor.sourceUrlEmpty')}</small>
+          )}
+        </div>
+
         <div className="editor-section-actions">
           <button onClick={() => navigate('/library')}>{t('common.cancel')}</button>
           <button

--- a/src/renderer/src/pages/PlaylistsPage.tsx
+++ b/src/renderer/src/pages/PlaylistsPage.tsx
@@ -227,6 +227,19 @@ function PlaylistDetail({ playlist }: { playlist: Playlist }) {
         </button>
       </div>
 
+      {playlist.sourceUrl && (
+        <div className="editor-file-location" style={{ marginBottom: 16 }}>
+          <span className="editor-file-location-label">{t('editor.sourceUrl')}</span>
+          <code>{playlist.sourceUrl}</code>
+          <button
+            onClick={() => void window.fmusic.openExternal(playlist.sourceUrl!)}
+            title={t('editor.openSource')}
+          >
+            {t('editor.openSource')}
+          </button>
+        </div>
+      )}
+
       {pickerOpen && (
         <div className="picker-card">
           <div className="picker-toolbar">

--- a/src/shared/i18n/en.json
+++ b/src/shared/i18n/en.json
@@ -162,7 +162,11 @@
     "fileLocation": "Location",
     "renameFailed": "Could not rename the file: {detail}",
     "audioDescription": "Trim the audio, add fades or change the volume. Overwrite the original file or export a new track.",
-    "untitledFallback": "Untitled"
+    "untitledFallback": "Untitled",
+    "sourceUrl": "Source URL",
+    "sourceUrlDescription": "Original URL this track was downloaded from.",
+    "sourceUrlEmpty": "No source URL recorded for this track.",
+    "openSource": "Open source"
   },
   "settings": {
     "title": "Settings",

--- a/src/shared/i18n/es.json
+++ b/src/shared/i18n/es.json
@@ -162,7 +162,11 @@
     "fileLocation": "Ubicación",
     "renameFailed": "No se ha podido renombrar el fichero: {detail}",
     "audioDescription": "Recorta el audio, añade fundidos o cambia el volumen. Puedes sobreescribir el original o exportar una nueva pista.",
-    "untitledFallback": "Sin título"
+    "untitledFallback": "Sin título",
+    "sourceUrl": "URL de origen",
+    "sourceUrlDescription": "URL original desde la que se descargó esta canción.",
+    "sourceUrlEmpty": "No hay URL de origen registrada para esta canción.",
+    "openSource": "Abrir origen"
   },
   "settings": {
     "title": "Ajustes",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -73,6 +73,12 @@ export interface Track {
   downloadedAt: string;
   playCount: number;
   lastPlayedAt: string | null;
+  /**
+   * URL the track was originally downloaded from (typically a YouTube watch
+   * URL). Null for tracks with no external origin, e.g. entries created by
+   * the in-app audio editor's "export" mode.
+   */
+  sourceUrl: string | null;
 }
 
 export interface TrackMetadataSuggestions {
@@ -111,6 +117,11 @@ export interface Playlist {
   createdAt: string;
   coverPath: string | null;
   trackCount: number;
+  /**
+   * URL the playlist was imported from (typically a YouTube playlist URL).
+   * Null for user-created playlists.
+   */
+  sourceUrl: string | null;
 }
 
 export interface PlaylistWithTracks extends Playlist {


### PR DESCRIPTION
Closes #11.

## Summary
- Adds migration `005_source_urls.sql` with a `source_url` column on both `tracks` and `playlists`.
- Downloaded tracks store the YouTube URL they were queued with (from `DownloadRequest.url`).
- Local playlists created from a YouTube playlist import store the playlist URL.
- The URL is surfaced only on the track Edit page (with an "Open source" action) and on the playlist detail view. It stays out of the library table, playlist list, player bar and other general UI surfaces.
- Shared `Track` / `Playlist` types, preload API, IPC `playlists:create`, and test fixtures updated accordingly.

## Test plan
- [x] ` npm run typecheck` passes
- [x] `npm test` passes (85 tests)
- [x] `npm run build` succeeds
- [x] Download a YouTube track → open Edit page → source URL shows with "Open source"
- [x] Import a YouTube playlist → open the playlist → playlist source URL shows with "Open source"
- [x] Library table / playlist list / player bar still show no URL
