### PR TITLE
fix: sync Sonos volume with player UI when casting starts

### DIFF
--- a/src/renderer/src/__tests__/SonosStore.test.ts
+++ b/src/renderer/src/__tests__/SonosStore.test.ts
@@ -93,4 +93,14 @@ describe('useSonosStore', () => {
     expect(mockNext).not.toHaveBeenCalled();
     expect(useSonosStore.getState().isPlaying).toBe(false);
   });
+
+  it('syncs volume when starting to cast', async () => {
+    mockPlayerGetState.mockReturnValue({
+      volume: 0.75
+    });
+
+    await useSonosStore.getState().startCasting('192.168.1.50', 123);
+
+    expect(window.fmusic.sonosSetVolume).toHaveBeenCalledWith('192.168.1.50', 0.75);
+  });
 });

--- a/src/renderer/src/store/sonos.ts
+++ b/src/renderer/src/store/sonos.ts
@@ -118,6 +118,10 @@ export const useSonosStore = create<SonosState>((set, get) => ({
         duration: 0,
         transportState: 'TRANSITIONING'
       });
+
+      // Sync current volume to the device immediately
+      await get().setVolume(usePlayerStore.getState().volume);
+
       get().startPositionPolling();
       if (seekTo && seekTo > 0) {
         // Sonos needs time to buffer before accepting a seek


### PR DESCRIPTION
Fixes #16. Pushes the current player volume to the Sonos device immediately after starting to cast, ensuring consistent volume levels between the UI and the speaker.