### PR TITLE
fix: prevent multiple app instances using single instance lock

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -248,8 +248,21 @@ function configureSecurity(): void {
   });
 }
 
-app.whenReady().then(() => {
-  try {
+const isSingleInstance = app.requestSingleInstanceLock();
+
+if (!isSingleInstance) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      if (!mainWindow.isVisible()) mainWindow.show();
+      mainWindow.focus();
+    }
+  });
+
+  app.whenReady().then(() => {
+    try {
     getDb();
     ensureBuiltinPlaylists();
     if (screenshotMode) {
@@ -393,3 +406,4 @@ app.on('before-quit', () => {
   stopUnifiedServer();
   closeDb();
 });
+}


### PR DESCRIPTION
Fixes #28. Implements app.requestSingleInstanceLock() to ensure only one instance of the application runs at a time. If a second instance is launched, it restores and focuses the existing window instead of starting a new process.