### PR TITLE
fix: Error in player when disabling sonos if already streaming

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -51,7 +51,7 @@ import {
   updateSmartPlaylist
 } from './library/playlists-repo.js';
 import { getSchemaHistory } from './library/db.js';
-import { discoverSonos, addSonosByIp, initSonosFromCache, sonosPlayTrack, sonosPause, sonosResume, sonosStop, sonosSetVolume, sonosSeek, sonosGetPosition } from './sonos.js';
+import { discoverSonos, addSonosByIp, initSonosFromCache, sonosPlayTrack, sonosPause, sonosResume, sonosStop, stopActiveSonos, sonosSetVolume, sonosSeek, sonosGetPosition } from './sonos.js';
 import { getTrackHttpUrl } from './sonos-server.js';
 import { generateTrackMobileUrl } from './mobile-server.js';
 import {
@@ -119,7 +119,7 @@ export function registerIpc(): void {
 
   // ----- Settings -----
   ipcMain.handle(Channels.SettingsGet, () => getSettings());
-  ipcMain.handle(Channels.SettingsUpdate, (_evt, patch: Partial<AppSettings>) => {
+  ipcMain.handle(Channels.SettingsUpdate, async (_evt, patch: Partial<AppSettings>) => {
     const prev = getSettings();
     const next = updateSettings(patch);
 
@@ -130,7 +130,7 @@ export function registerIpc(): void {
       broadcastRemoteControllerSettings();
     }
 
-    function updateServerLifecycle() {
+    async function updateServerLifecycle() {
       const s = getSettings();
       if (s.mobileSyncEnabled || s.remoteControllerEnabled || s.sonosEnabled) {
         void startUnifiedServer().catch(console.error);
@@ -148,6 +148,10 @@ export function registerIpc(): void {
     ) {
       if (patch.sonosEnabled !== undefined) {
         console.log(`[settings] Sonos integration ${patch.sonosEnabled ? 'enabled' : 'disabled'}`);
+        if (!patch.sonosEnabled) {
+          // IMPORTANT: Stop playback before the server (which hosts the files) is shut down
+          await stopActiveSonos();
+        }
       }
       if (patch.mobileSyncEnabled !== undefined) {
         console.log(`[settings] Mobile sync ${patch.mobileSyncEnabled ? 'enabled' : 'disabled'}`);
@@ -155,7 +159,7 @@ export function registerIpc(): void {
       if (patch.remoteControllerEnabled !== undefined) {
         console.log(`[settings] Remote controller ${patch.remoteControllerEnabled ? 'enabled' : 'disabled'}`);
       }
-      updateServerLifecycle();
+      await updateServerLifecycle();
     }
 
     // Notify every renderer (main window, mini player, …) so they can keep
@@ -372,19 +376,27 @@ export function registerIpc(): void {
     return sonosResume(host);
   });
   ipcMain.handle(Channels.SonosStop, async (_evt, host: string) => {
-    await ensureSonosEnabled();
-    return sonosStop(host);
+    try {
+      return await sonosStop(host);
+    } catch (err) {
+      console.error(`[ipc] Error in sonos:stop for ${host}:`, err);
+      throw err;
+    }
   });
   ipcMain.handle(Channels.SonosVolume, async (_evt, host: string, volume: number) => {
-    await ensureSonosEnabled();
+    if (!getSettings().sonosEnabled) return;
     return sonosSetVolume(host, volume);
   });
+
   ipcMain.handle(Channels.SonosSeek, async (_evt, host: string, seconds: number) => {
-    await ensureSonosEnabled();
+    if (!getSettings().sonosEnabled) return;
     return sonosSeek(host, seconds);
   });
+
   ipcMain.handle(Channels.SonosPosition, async (_evt, host: string) => {
-    await ensureSonosEnabled();
+    if (!getSettings().sonosEnabled) {
+      return { position: 0, duration: 0, transportState: 'STOPPED' };
+    }
     return sonosGetPosition(host);
   });
 

--- a/src/main/server-manager.ts
+++ b/src/main/server-manager.ts
@@ -4,10 +4,17 @@ import { getSettings } from './settings.js';
 import { registerServicePort, unregisterServicePort } from './network.js';
 import { handleRemoteRequest, handleRemoteUpgrade, isRemoteEnabled } from './remote-controller-server.js';
 import { handleMobileRequest, isMobileSyncEnabled } from './mobile-server.js';
-import { handleSonosRequest, isSonosEnabled } from './sonos-server.js';
+import { handleSonosRequest } from './sonos-server.js';
 
 let server: http.Server | null = null;
 let serverPort = 0;
+
+export function isSonosEnabled(): boolean {
+  // We check if the setting is enabled OR if the server is still running.
+  // This allows the Sonos speaker to finish its current buffer/request
+  // during the split second between the setting change and the server shutdown.
+  return getSettings().sonosEnabled || server !== null;
+}
 
 export async function startUnifiedServer(): Promise<number> {
   if (server) return serverPort;

--- a/src/main/sonos-server.ts
+++ b/src/main/sonos-server.ts
@@ -74,6 +74,4 @@ export function getTrackHttpUrl(trackId: number, filePath?: string): string {
   return `http://${getLocalIp()}:${port}/track/${trackId}${ext}`;
 }
 
-export function isSonosEnabled(): boolean {
-  return getSettings().sonosEnabled;
-}
+

--- a/src/renderer/src/__tests__/PlayerBar.test.tsx
+++ b/src/renderer/src/__tests__/PlayerBar.test.tsx
@@ -11,7 +11,7 @@ vi.mock('../store/library');
 vi.mock('../store/sonos');
 vi.mock('../store/settings', () => ({
   useSettingsStore: vi.fn((selector?: unknown) => {
-    const state = { settings: { language: 'en', sonosEnabled: false } };
+    const state = { settings: { language: 'en', sonosEnabled: true } };
     return typeof selector === 'function' ? selector(state) : state;
   }),
 }));
@@ -84,6 +84,7 @@ function makeSonosState(overrides = {}) {
     seek: vi.fn().mockResolvedValue(undefined),
     seekBy: vi.fn().mockResolvedValue(undefined),
     sendTrack: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/src/renderer/src/components/PlayerBar.tsx
+++ b/src/renderer/src/components/PlayerBar.tsx
@@ -44,6 +44,13 @@ export function PlayerBar() {
   const sonos = useSonosStore();
   const isCasting = sonos.activeHost !== null;
 
+  // If sonos is disabled while casting, stop it and revert to local playback
+  useEffect(() => {
+    if (!sonosEnabled && isCasting) {
+      void sonos.stop();
+    }
+  }, [sonosEnabled, isCasting, sonos]);
+
   // When casting and the local player advances to a new track, forward it to Sonos.
   const prevTrackId = useRef<number | null>(null);
   useEffect(() => {


### PR DESCRIPTION
This fixes the error in the player whenever the sonos was already streaming or casting and the integration was stopped.